### PR TITLE
Fix undefined references

### DIFF
--- a/tools/workspace/glib/package.BUILD
+++ b/tools/workspace/glib/package.BUILD
@@ -36,7 +36,10 @@ cc_library(
     ]) + [
         "glib/glibconfig.h",
     ],
-    deps = [":config"],
+    deps = [
+        ":config",
+        "@pcre",
+    ],
     copts = [
         "-I$(GENDIR)/external/glib/glibprivate",
         "-DGLIB_COMPILATION",
@@ -157,7 +160,12 @@ cc_library(
 	"gprintf.c",
 	"gprintfint.h",
 	"valgrind.h",
-        "libcharset/localcharset.c",
+	"libcharset/localcharset.c",
+	"deprecated/gallocator.c",
+	"deprecated/gcache.c",
+	"deprecated/gcompletion.c",
+	"deprecated/grel.c",
+	"deprecated/gthread-deprecated.c",
     ]],
 )
 

--- a/tools/workspace/pcre/package.BUILD
+++ b/tools/workspace/pcre/package.BUILD
@@ -92,8 +92,10 @@ autoconf_config(
     version = "8.42",
     defines = autoconf_standard_defines + [
         "LINK_SIZE=2",
+        "SUPPORT_UCP=1",
         "MATCH_LIMIT=1000000",
         "MATCH_LIMIT_RECURSION=MATCH_LIMIT",
+        "SUPPORT_UTF=1",
         "MAX_NAME_COUNT=10000",
         "MAX_NAME_SIZE=32",
         "NEWLINE=10",


### PR DESCRIPTION
When using libraries that use glib's deprecated features, I was getting undefined reference errors. This fixes that. As a separate commit my formatter also reformatted the build files to be more consistent.