### PR TITLE
Update Boost download url

### DIFF
--- a/tools/workspace/boost/repository.bzl
+++ b/tools/workspace/boost/repository.bzl
@@ -21,7 +21,7 @@ def boost_repository(name):
     http_archive(
         name = name,
         urls = [
-            "https://boostorg.jfrog.io/artifactory/main/release/1.74.0/source/boost_1_74_0.tar.gz",
+            "https://archives.boost.io/release/1.74.0/source/boost_1_74_0.tar.gz",
         ],
         sha256 = "afff36d392885120bcac079148c177d1f6f7730ec3d47233aa51b0afa4db94a5",
         strip_prefix = "boost_1_74_0",


### PR DESCRIPTION
The Jfrog page is no longer active, causing a download error. This commit changes it to archives.boost.io